### PR TITLE
Add Client Configurations

### DIFF
--- a/cosmos/cosmos.go
+++ b/cosmos/cosmos.go
@@ -22,12 +22,20 @@ type Client struct {
 	rLink      string
 }
 
+type Option func(*Client)
+
+func WithClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = client
+	}
+}
+
 func (c *Client) getURL() string {
 	return c.domain + c.path
 }
 
 // New create a new CosmosDB instance
-func New(connString string) (*Client, error) {
+func New(connString string, opts ...Option) (*Client, error) {
 	if connString == "" {
 		return nil, errors.New("Invalid connection string")
 	}
@@ -41,7 +49,14 @@ func New(connString string) (*Client, error) {
 		return nil, errors.New("Invalid connection string")
 	}
 	httpClient := &http.Client{}
-	return &Client{key, path, path, "", httpClient, "", ""}, nil
+
+	c := &Client{key, path, path, "", httpClient, "", ""}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	return c, nil
 }
 
 // Offer defines all operation on a single offer

--- a/cosmos/cosmos.go
+++ b/cosmos/cosmos.go
@@ -22,14 +22,6 @@ type Client struct {
 	rLink      string
 }
 
-type Option func(*Client)
-
-func WithClient(client *http.Client) Option {
-	return func(c *Client) {
-		c.httpClient = client
-	}
-}
-
 func (c *Client) getURL() string {
 	return c.domain + c.path
 }
@@ -199,4 +191,14 @@ func stringify(body interface{}) (bt []byte, err error) {
 		bt, err = Serialization.Marshal(t)
 	}
 	return
+}
+
+// Option funcitons for configuring the client
+type Option func(*Client)
+
+// WithClient allows you to provide a custom http client
+func WithClient(client *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = client
+	}
 }

--- a/dbtest/documents_test.go
+++ b/dbtest/documents_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spacycoder/cosmosdb-go-sdk/cosmos"
+	"github.com/sethjback/cosmosdb-go-sdk/cosmos"
 )
 
 func getClient() (*cosmos.Client, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spacycoder/cosmosdb-go-sdk
+module github.com/sethjback/cosmosdb-go-sdk
 
 go 1.12
 

--- a/qbuilder/qbuilder.go
+++ b/qbuilder/qbuilder.go
@@ -1,6 +1,6 @@
 package qbuilder
 
-import "github.com/spacycoder/cosmosdb-go-sdk/cosmos"
+import "github.com/sethjback/cosmosdb-go-sdk/cosmos"
 
 type Condition struct {
 	ConditionType string

--- a/qbuilder/qbuilder_test.go
+++ b/qbuilder/qbuilder_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/spacycoder/cosmosdb-go-sdk/cosmos"
+	"github.com/sethjback/cosmosdb-go-sdk/cosmos"
 )
 
 func TestQueryBuilder(t *testing.T) {


### PR DESCRIPTION
To use the cosmosdb emulator, you need to disable tls checking in the http client. This adds the option pattern to `New` and implemnts an option for providing your own http client.